### PR TITLE
DnsServerAddress: Making Get/Test less suicidal.

### DIFF
--- a/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
+++ b/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
@@ -51,9 +51,17 @@ function Get-TargetResource
     $null = $PSBoundParameters.Remove('Address')
 
     # Get the current DNS Server Addresses based on the parameters given.
-    [String[]] $currentAddress = Get-DnsClientServerStaticAddress `
-        @PSBoundParameters `
-        -ErrorAction Stop
+    [String[]] $currentAddress = try {
+        Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
+    } catch {
+        Write-Verbose -Message (
+            -join @(
+                "$($MyInvocation.MyCommand): "
+                $($script:localizedData.GettingDnsServerAddressesMessage -f $InterfaceAlias, $_.Message)
+            )
+        )
+        @()
+    }
 
     $returnValue = @{
         Address        = $currentAddress
@@ -248,9 +256,19 @@ function Test-TargetResource
     $null = $PSBoundParameters.Remove('Validate')
 
     # Get the current DNS Server Addresses based on the parameters given.
-    [String[]] $currentAddress = @(Get-DnsClientServerStaticAddress `
-        @PSBoundParameters `
-        -ErrorAction Stop)
+    [String[]] $currentAddress = @(
+        try {
+            Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
+        } catch {
+            Write-Verbose -Message (
+                -join @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.GettingDnsServerAddressesMessage -f $InterfaceAlias, $_.Message)
+                )
+            )
+            return $false
+        }
+    )
 
     # Check if the Server addresses are the same as the desired addresses.
     [Boolean] $addressDifferent = (@(Compare-Object `

--- a/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
+++ b/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
@@ -134,10 +134,10 @@ function Set-TargetResource
     $null = $PSBoundParameters.Remove('Validate')
 
     # Get the current DNS Server Addresses based on the parameters given.
-    [String[]] $currentAddress =
+    [String[]] $currentAddress = @(
         try
         {
-            @(Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop)
+            Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
         }
         catch
         {
@@ -149,6 +149,7 @@ function Set-TargetResource
             )
             return
         }
+    )
 
     # Check if the Server addresses are the same as the desired addresses.
     [Boolean] $addressDifferent = (@(Compare-Object `

--- a/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
+++ b/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
@@ -51,17 +51,21 @@ function Get-TargetResource
     $null = $PSBoundParameters.Remove('Address')
 
     # Get the current DNS Server Addresses based on the parameters given.
-    [String[]] $currentAddress = try {
-        Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
-    } catch {
-        Write-Verbose -Message (
-            -join @(
-                "$($MyInvocation.MyCommand): "
-                $($script:localizedData.GettingDnsServerAddressesMessage -f $InterfaceAlias, $_.Message)
+    [String[]] $currentAddress =
+        try
+        {
+            Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
+        }
+        catch
+        {
+            Write-Warning -Message (
+                -join @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Message)
+                )
             )
-        )
-        @()
-    }
+            @()
+        }
 
     $returnValue = @{
         Address        = $currentAddress
@@ -257,13 +261,16 @@ function Test-TargetResource
 
     # Get the current DNS Server Addresses based on the parameters given.
     [String[]] $currentAddress = @(
-        try {
+        try
+        {
             Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop
-        } catch {
-            Write-Verbose -Message (
+        }
+        catch
+        {
+            Write-Warning -Message (
                 -join @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.GettingDnsServerAddressesMessage -f $InterfaceAlias, $_.Message)
+                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Message)
                 )
             )
             return $false

--- a/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
+++ b/DSCResources/MSFT_DnsServerAddress/MSFT_DnsServerAddress.psm1
@@ -61,7 +61,7 @@ function Get-TargetResource
             Write-Warning -Message (
                 -join @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Message)
+                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Exception.Message)
                 )
             )
             @()
@@ -134,9 +134,21 @@ function Set-TargetResource
     $null = $PSBoundParameters.Remove('Validate')
 
     # Get the current DNS Server Addresses based on the parameters given.
-    [String[]] $currentAddress = @(Get-DnsClientServerStaticAddress `
-        @PSBoundParameters `
-        -ErrorAction Stop)
+    [String[]] $currentAddress =
+        try
+        {
+            @(Get-DnsClientServerStaticAddress @PSBoundParameters -ErrorAction Stop)
+        }
+        catch
+        {
+            Write-Error -Message (
+                -join @(
+                    "$($MyInvocation.MyCommand): "
+                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Exception.Message)
+                )
+            )
+            return
+        }
 
     # Check if the Server addresses are the same as the desired addresses.
     [Boolean] $addressDifferent = (@(Compare-Object `
@@ -270,7 +282,7 @@ function Test-TargetResource
             Write-Warning -Message (
                 -join @(
                     "$($MyInvocation.MyCommand): "
-                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Message)
+                    $($script:localizedData.DnsInformationNotFound -f $InterfaceAlias, $_.Exception.Message)
                 )
             )
             return $false

--- a/DSCResources/MSFT_DnsServerAddress/en-US/MSFT_DnsServerAddress.strings.psd1
+++ b/DSCResources/MSFT_DnsServerAddress/en-US/MSFT_DnsServerAddress.strings.psd1
@@ -13,4 +13,5 @@ ConvertFrom-StringData @'
     AddressFormatError                    = Address "{0}" is not in the correct format. Please correct the Address parameter in the configuration and try again.
     AddressIPv4MismatchError              = Address "{0}" is in IPv4 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
     AddressIPv6MismatchError              = Address "{0}" is in IPv6 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
+    DnsInformationNotFound                = Could not retrieve DNS address for interface "{0}" - "{1}".
 '@

--- a/Tests/Unit/MSFT_DnsServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_DnsServerAddress.Tests.ps1
@@ -610,6 +610,11 @@ try
                 Mock -CommandName Get-DnsClientServerStaticAddress -MockWith {
                     throw 'Interface not found'
                 }
+                Mock -CommandName Get-NetAdapter -MockWith {
+                    [PSObject]@{
+                        Name = 'Ethernet'
+                    }
+                }
 
                 It 'Should return false and write-warning' {
                     $testTargetResourceSplat = @{


### PR DESCRIPTION
#### Pull Request (PR) description
I noticed that DnsServerAddress will throw if/when interface with a given alias is not found, resulting in whole `Test-DscResource` / `Get-DscResource` failing, making it impossible to fix what *else* is not in desired state.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/networkingdsc/420)
<!-- Reviewable:end -->
