### PR TITLE
NetworkingDsc: Fix link typo (to wiki) in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed IDs of Azure DevOps pipeline in badges in README.MD - Fixes
   [Issue #438](https://github.com/dsccommunity/NetworkingDsc/issues/438).
- - Fixed typo in link to Wiki in README.MD
+- Fixed typo in link to Wiki in README.MD
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed IDs of Azure DevOps pipeline in badges in README.MD - Fixes
   [Issue #438](https://github.com/dsccommunity/NetworkingDsc/issues/438).
+ - Fixed typo in link to Wiki in README.MD
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The **NetworkingDsc** module contains the following resources:
 ## Documentation and Examples
 
 For a full list of resources in NetworkingDsc and examples on their use, check out
-the [NetworkingDsc wiki](https://github.com/dsccomunnity/NetworkingDsc/wiki).
+the [NetworkingDsc wiki](https://github.com/dsccommunity/NetworkingDsc/wiki).
 
 ## Known Issues
 


### PR DESCRIPTION
Just a typo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/networkingdsc/440)
<!-- Reviewable:end -->
