### PR TITLE
Fix NetBios Wildcard Support - Fixes #444

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merge `HISTORIC_CHANGELOG.md` into `CHANGELOG.md` - Fixes [Issue #451](https://github.com/dsccommunity/NetworkingDsc/issues/451).
 - NetBios:
   - Improved integration tests by using loopback adapter.
+  - Refactored unit tests to reduce code duplication and
+    increase coverage.
   - Fix exception when specifying wildcard '*' in the
     `InterfaceAlias` - Fixes [Issue #444](https://github.com/dsccommunity/NetworkingDsc/issues/444).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- ComputerManagementDsc
+- NetworkingDsc:
   - Added build task `Generate_Conceptual_Help` to generate conceptual help
     for the DSC resource.
   - Added build task `Generate_Wiki_Content` to generate the wiki content
     that can be used to update the GitHub Wiki.
-- Common
+- Common:
   - Added Assert-IPAddress function to reduce code duplication - Fixes
     [Issue #408](https://github.com/dsccommunity/NetworkingDsc/issues/408).
 
 ### Changed
 
-- NetworkingDsc
+- NetworkingDsc:
   - Updated to use the common module _DscResource.Common_.
   - Fixed build failures caused by changes in `ModuleBuilder` module v1.7.0
     by changing `CopyDirectories` to `CopyPaths` - Fixes [Issue #455](https://github.com/dsccommunity/NetworkingDsc/issues/455).
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change Azure DevOps Pipeline definition to include `source/*` - Fixes [Issue #450](https://github.com/dsccommunity/NetworkingDsc/issues/450).
 - Updated pipeline to use `latest` version of `ModuleBuilder` - Fixes [Issue #451](https://github.com/dsccommunity/NetworkingDsc/issues/451).
 - Merge `HISTORIC_CHANGELOG.md` into `CHANGELOG.md` - Fixes [Issue #451](https://github.com/dsccommunity/NetworkingDsc/issues/451).
+- NetBios:
+  - Improved integration tests by using loopback adapter.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Merge `HISTORIC_CHANGELOG.md` into `CHANGELOG.md` - Fixes [Issue #451](https://github.com/dsccommunity/NetworkingDsc/issues/451).
 - NetBios:
   - Improved integration tests by using loopback adapter.
+  - Fix exception when specifying wildcard '*' in the
+    `InterfaceAlias` - Fixes [Issue #444](https://github.com/dsccommunity/NetworkingDsc/issues/444).
 
 ### Deprecated
 

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -246,7 +246,7 @@ function Test-TargetResource
 
     $currentState = Get-TargetResource @PSBoundParameters
 
-    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters -Verbose
+    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -228,22 +228,6 @@ function Test-TargetResource
 
     Write-Verbose -Message ($script:localizedData.TestingNetBiosSettingMessage -f $InterfaceAlias)
 
-    $win32NetworkAdapterFilter = Format-Win32NetworkAdapterFilterByNetConnectionId -InterfaceAlias $InterfaceAlias
-
-    $netAdapter = Get-CimInstance `
-        -ClassName Win32_NetworkAdapter `
-        -Filter $win32NetworkAdapterFilter
-
-    if ($netAdapter)
-    {
-        Write-Verbose -Message ($script:localizedData.InterfaceDetectedMessage -f $InterfaceAlias, ($netAdapter.InterfaceIndex -Join ','))
-    }
-    else
-    {
-        New-InvalidOperationException `
-            -Message ($script:localizedData.InterfaceNotFoundError -f $InterfaceAlias)
-    }
-
     $currentState = Get-TargetResource @PSBoundParameters
 
     return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -82,7 +82,7 @@ function Get-TargetResource
         be returned for the first adapter that does not match
         the desired value. This is to ensure that when testing
         the resource state it will return a mismatch if any adapters
-        are don't have the correct setting
+        don't have the correct setting.
     #>
     foreach ($netAdapterItem in $netAdapter)
     {

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -246,7 +246,7 @@ function Test-TargetResource
 
     $currentState = Get-TargetResource @PSBoundParameters
 
-    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters
+    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters -Verbose
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -106,7 +106,7 @@ function Get-TargetResource
         if ($interfaceSetting -ne $Setting)
         {
             $Setting = $interfaceSetting
-            exit
+            break
         }
     }
 

--- a/source/DSCResources/DSC_NetBios/en-US/DSC_NetBios.strings.psd1
+++ b/source/DSCResources/DSC_NetBios/en-US/DSC_NetBios.strings.psd1
@@ -4,10 +4,10 @@ ConvertFrom-StringData @'
     GettingNetBiosSettingMessage = Getting NetBIOS configuration for Interface '{0}'.
     InterfaceDetectedMessage = Interface '{0}' detected with Index number {1}.
     SettingNetBiosSettingMessage = Setting NetBIOS configuration for Interface '{0}'.
-    ResetToDefaultMessage = NetBIOS configuration will be reset to default.
-    SetNetBiosMessage = NetBIOS configuration will be set to '{0}'.
+    ResetToDefaultMessage = NetBIOS configuration for Interface '{0}' will be reset to default.
+    SetNetBiosMessage = NetBIOS configuration for Interface '{0}' will be set to '{1}'.
     TestingNetBiosSettingMessage = Testing NetBIOS configuration for Interface '{0}'.
-    CurrentNetBiosSettingMessage = Current NetBIOS configuration is '{0}'.
+    CurrentNetBiosSettingMessage = Current NetBIOS configuration for Interface '{0}' is '{1}'.
     InterfaceNotFoundError = Interface '{0}' was not found.
-    FailedUpdatingNetBiosError = An error result of '{0}' was returned when attemting to set NetBIOS configuration to '{1}'.
+    FailedUpdatingNetBiosError = An error result of '{1}' was returned when attemting to set NetBIOS for Interface '{0}' configuration to '{2}'.
 '@

--- a/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -541,7 +541,7 @@ function Get-IPAddressPrefix
 .PARAMETER InterfaceAlias
     Specifies the alias of a network interface. Supports the use of '*' or '%'.
 #>
-function Format-Win32NetworkAdapterFilterByNetConnectionID
+function Format-Win32NetworkAdapterFilterByNetConnectionId
 {
     [CmdletBinding()]
     [OutputType([System.String])]
@@ -566,9 +566,9 @@ function Format-Win32NetworkAdapterFilterByNetConnectionID
         $operator = '='
     }
 
-    $returnNetAdapaterFilter = 'NetConnectionID{0}"{1}"' -f $operator,$InterfaceAlias
+    $returnNetAdapaterFilter = 'NetConnectionID{0}"{1}"' -f $operator, $InterfaceAlias
 
-    $returnNetAdapaterFilter
+    return $returnNetAdapaterFilter
 }
 
 Export-ModuleMember -Function @(
@@ -578,5 +578,5 @@ Export-ModuleMember -Function @(
     'Get-WinsClientServerStaticAddress'
     'Set-WinsClientServerStaticAddress'
     'Get-IPAddressPrefix'
-    'Format-Win32NetworkAdapterFilterByNetConnectionID'
+    'Format-Win32NetworkAdapterFilterByNetConnectionId'
 )

--- a/tests/Integration/DSC_NetBios.Integration.Tests.ps1
+++ b/tests/Integration/DSC_NetBios.Integration.Tests.ps1
@@ -23,8 +23,11 @@ try
 {
     Describe 'NetBios Integration Tests' {
         # Configure Loopback Adapters
-        $netAdapter1 = New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
-        $netAdapter2 = New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+        New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
+        New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+
+        $netAdapter1 = Get-NetAdapter -Name 'NetworkingDscLBA1'
+        $netAdapter2 = Get-NetAdapter -Name 'NetworkingDscLBA2'
 
         $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
         . $configFile -Verbose -ErrorAction Stop
@@ -182,5 +185,9 @@ public enum NetBiosSetting
 }
 finally
 {
+    # Remove Loopback Adapters
+    Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
+    Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }

--- a/tests/Integration/DSC_NetBios.Integration.Tests.ps1
+++ b/tests/Integration/DSC_NetBios.Integration.Tests.ps1
@@ -26,9 +26,6 @@ try
         New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
         New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
 
-        Get-NetAdapter -Name 'NetworkingDscLBA1'
-        Get-NetAdapter -Name 'NetworkingDscLBA2'
-
         $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
         . $configFile -Verbose -ErrorAction Stop
 
@@ -133,8 +130,8 @@ function Invoke-NetBiosIntegrationTest
 finally
 {
     # Remove Loopback Adapters
-    Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
     Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+    Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
 
     Restore-TestEnvironment -TestEnvironment $script:testEnvironment
 }

--- a/tests/Integration/DSC_NetBios.Integration.Tests.ps1
+++ b/tests/Integration/DSC_NetBios.Integration.Tests.ps1
@@ -101,16 +101,30 @@ function Invoke-NetBiosIntegrationTest
 
         Describe "$($script:dscResourceName)_Integration" {
             Context 'When applying to a single network adapter' {
-                Context 'When Disable NetBios over TCP/IP' {
+                Context 'When setting NetBios over TCP/IP to Disable' {
                     Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA1' -Setting 'Disable'
                 }
 
-                Context 'Enable NetBios over TCP/IP' {
+                Context 'When setting NetBios over TCP/IP to Enable' {
                     Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA1' -Setting 'Enable'
                 }
 
-                Context 'Default NetBios over TCP/IP' {
+                Context 'When setting NetBios over TCP/IP to Default' {
                     Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA1' -Setting 'Default'
+                }
+            }
+
+            Context 'When applying to a all network adapters' {
+                Context 'When setting NetBios over TCP/IP to Disable' {
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Disable'
+                }
+
+                Context 'When setting NetBios over TCP/IP to Enable' {
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Enable'
+                }
+
+                Context 'When setting NetBios over TCP/IP to Default' {
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Default'
                 }
             }
         }

--- a/tests/Integration/DSC_NetBios.Integration.Tests.ps1
+++ b/tests/Integration/DSC_NetBios.Integration.Tests.ps1
@@ -116,15 +116,15 @@ function Invoke-NetBiosIntegrationTest
 
             Context 'When applying to a all network adapters' {
                 Context 'When setting NetBios over TCP/IP to Disable' {
-                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Disable'
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA*' -Setting 'Disable'
                 }
 
                 Context 'When setting NetBios over TCP/IP to Enable' {
-                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Enable'
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA*' -Setting 'Enable'
                 }
 
                 Context 'When setting NetBios over TCP/IP to Default' {
-                    Invoke-NetBiosIntegrationTest -InterfaceAlias '*' -Setting 'Default'
+                    Invoke-NetBiosIntegrationTest -InterfaceAlias 'NetworkingDscLBA*' -Setting 'Default'
                 }
             }
         }

--- a/tests/Unit/DSC_NetBios.Tests.ps1
+++ b/tests/Unit/DSC_NetBios.Tests.ps1
@@ -71,7 +71,7 @@ try
             -PassThru
 
         Describe 'DSC_NetBios\Get-TargetResource' -Tag 'Get' {
-            Context 'NetBios over TCP/IP is set to "Default"' {
+            Context 'When NetBios over TCP/IP is set to "Default"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDefault }
 
@@ -90,7 +90,7 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP is set to "Enable"' {
+            Context 'When NetBios over TCP/IP is set to "Enable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
 
@@ -109,7 +109,7 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP is set to "Disable"' {
+            Context 'When NetBios over TCP/IP is set to "Disable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
 
@@ -128,7 +128,7 @@ try
                 }
             }
 
-            Context 'Interface does not exist' {
+            Context 'When interface does not exist' {
                 Mock -CommandName Get-CimInstance -MockWith { }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
 
@@ -144,7 +144,7 @@ try
         }
 
         Describe 'DSC_NetBios\Test-TargetResource' -Tag 'Test' {
-            Context 'NetBios over TCP/IP is set to "Default"' {
+            Context 'When NetBios over TCP/IP is set to "Default"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDefault }
 
@@ -157,7 +157,7 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP is set to "Disable"' {
+            Context 'When NetBios over TCP/IP is set to "Disable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
 
@@ -170,7 +170,7 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP is set to "Enable"' {
+            Context 'When NetBios over TCP/IP is set to "Enable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
 
@@ -183,7 +183,7 @@ try
                 }
             }
 
-            Context 'Interface does not exist' {
+            Context 'When interface does not exist' {
                 Mock -CommandName Get-CimInstance -MockWith { }
 
                 $errorRecord = Get-InvalidOperationRecord `
@@ -198,11 +198,15 @@ try
         }
 
         Describe 'DSC_NetBios\Set-TargetResource' -Tag 'Set' {
-            Context 'NetBios over TCP/IP should be set to "Default"' {
+            Context 'When NetBios over TCP/IP should be set to "Default"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
                 Mock -CommandName Set-ItemProperty
-                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+                Mock -CommandName Invoke-CimMethod -MockWith {
+                    @{
+                        ReturnValue = 0
+                    }
+                }
 
                 It 'Should not throw exception' {
                     {
@@ -216,11 +220,13 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP should be set to "Disable"' {
+            Context 'When NetBios over TCP/IP should be set to "Disable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
                 Mock -CommandName Set-ItemProperty
-                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+                Mock -CommandName Invoke-CimMethod -MockWith { @{
+                    ReturnValue = 0
+                } }
 
                 It 'Should not throw exception' {
                     {
@@ -234,11 +240,15 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP should be set to "Enable"' {
+            Context 'When NetBios over TCP/IP should be set to "Enable"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
                 Mock -CommandName Set-ItemProperty
-                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+                Mock -CommandName Invoke-CimMethod -MockWith {
+                    @{
+                        ReturnValue = 0
+                    }
+                }
 
                 It 'Should not throw exception' {
                     {
@@ -253,14 +263,18 @@ try
                 }
             }
 
-            Context 'NetBios over TCP/IP should be set to "Enable" but error returned from "Invoke-CimMethod"' {
+            Context 'When NetBios over TCP/IP should be set to "Enable" but error returned from "Invoke-CimMethod"' {
                 Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
                 Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
-                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 74 } }
+                Mock -CommandName Invoke-CimMethod -MockWith {
+                    @{
+                        ReturnValue = 74
+                    }
+                }
                 Mock -CommandName Set-ItemProperty
 
                 $errorRecord = Get-InvalidOperationRecord `
-                    -Message ($script:localizedData.FailedUpdatingNetBiosError -f 74, 'Enable')
+                    -Message ($script:localizedData.FailedUpdatingNetBiosError -f $interfaceAlias, 74, 'Enable')
 
                 It 'Should throw expected exception' {
                     {
@@ -274,7 +288,7 @@ try
                 }
             }
 
-            Context 'Interface does not exist' {
+            Context 'When interface does not exist' {
                 Mock -CommandName Get-CimInstance -MockWith { }
 
                 $errorRecord = Get-InvalidOperationRecord `


### PR DESCRIPTION
#### Pull Request (PR) description

- NetBios:
  - Improved integration tests by using loopback adapter.
  - Refactored unit tests to reduce code duplication and
    increase coverage.
  - Fix exception when specifying wildcard '*' in the
    `InterfaceAlias` - Fixes [Issue #444](https://github.com/dsccommunity/NetworkingDsc/issues/444).

#### This Pull Request (PR) fixes the following issues

- Fixes #444

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing for me when you have time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/networkingdsc/458)
<!-- Reviewable:end -->
