### PR TITLE
NetIPInterface: Fix Parameter Mismatch Issue - Fixes #470

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- IPAddress
+  - Improved integration test structure.
+
+### Fixed
+
+- NetIPInterface
+  - Fix 'type mismatch for property' issue when setting 'AdvertiseDefaultRoute',
+    'Advertising', 'AutomaticMetric', 'Dhcp', 'DirectedMacWolPattern', 'EcnMarking',
+    'ForceArpNdWolPattern', 'Forwarding', 'IgnoreDefaultRoutes', 'ManagedAddressConfiguration',
+    'NeighborUnreachabilityDetection', 'OtherStatefulConfiguration', 'RouterDiscovery',
+    'WeakHostReceive' or 'WeakHostSend' - Fixes [Issue #470](https://github.com/dsccommunity/NetworkingDsc/issues/470).
+
 ## [8.1.0] - 2020-08-04
 
 ### Changed

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
@@ -430,7 +430,7 @@ function Test-TargetResource
 
     $currentState = Get-TargetResource @getTargetResourceParameters
 
-    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters -Verbose
+    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters -TurnOffTypeChecking
 }
 
 <#

--- a/tests/Integration/DSC_IPAddress.Integration.Tests.ps1
+++ b/tests/Integration/DSC_IPAddress.Integration.Tests.ps1
@@ -22,27 +22,27 @@ Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\TestHelpers\Co
 try
 {
     Describe 'IPAddress Integration Tests' {
-        New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
-
         $configFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:dscResourceName).config.ps1"
         . $configFile -Verbose -ErrorAction Stop
 
+        BeforeAll {
+            New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
+            New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+        }
+
+        AfterAll {
+            Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA1'
+            Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA2'
+        }
+
         Describe "$($script:dscResourceName)_Integration" {
-            BeforeEach {
-                New-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA'
-            }
-
-            AfterEach {
-                Remove-IntegrationLoopbackAdapter -AdapterName 'NetworkingDscLBA'
-            }
-
             Context 'When a single IP address is specified' {
                 # This is to pass to the Config
                 $configData = @{
                     AllNodes = @(
                         @{
                             NodeName       = 'localhost'
-                            InterfaceAlias = 'NetworkingDscLBA'
+                            InterfaceAlias = 'NetworkingDscLBA1'
                             AddressFamily  = 'IPv4'
                             IPAddress      = '10.11.12.13/16'
                         }
@@ -73,9 +73,9 @@ try
                     $current = Get-DscConfiguration | Where-Object -FilterScript {
                         $_.ConfigurationName -eq "$($script:dscResourceName)_Config"
                     }
-                    $current.InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
-                    $current.AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
-                    $current.IPAddress | Should -Be $configData.AllNodes[0].IPAddress
+                    $current[0].InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
+                    $current[0].AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
+                    $current[0].IPAddress | Should -Be $configData.AllNodes[0].IPAddress
                 }
             }
         }
@@ -86,7 +86,7 @@ try
                 AllNodes = @(
                     @{
                         NodeName       = 'localhost'
-                        InterfaceAlias = 'NetworkingDscLBA'
+                        InterfaceAlias = 'NetworkingDscLBA2'
                         AddressFamily  = 'IPv4'
                         IPAddress      = @('10.12.13.14/16', '10.13.14.16/32')
                     }
@@ -117,10 +117,10 @@ try
                 $current = Get-DscConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq "$($script:dscResourceName)_Config"
                 }
-                $current.InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
-                $current.AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
-                $current.IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[0]
-                $current.IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[1]
+                $current[0].InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
+                $current[0].AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
+                $current[0].IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[0]
+                $current[0].IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[1]
             }
         }
     }

--- a/tests/Integration/DSC_IPAddress.Integration.Tests.ps1
+++ b/tests/Integration/DSC_IPAddress.Integration.Tests.ps1
@@ -30,9 +30,68 @@ try
         . $configFile -Verbose -ErrorAction Stop
 
         Describe "$($script:dscResourceName)_Integration" {
+            Context 'When a single IP address is specified' {
+                It 'Should compile and apply the MOF without throwing' {
+                    {
+                        # This is to pass to the Config
+                        $configData = @{
+                            AllNodes = @(
+                                @{
+                                    NodeName       = 'localhost'
+                                    InterfaceAlias = 'NetworkingDscLBA'
+                                    AddressFamily  = 'IPv4'
+                                    IPAddress      = '10.11.12.13/16'
+                                }
+                            )
+                        }
+
+                        & "$($script:dscResourceName)_Config" `
+                            -OutputPath $TestDrive `
+                            -ConfigurationData $configData
+
+                        Start-DscConfiguration `
+                            -Path $TestDrive `
+                            -ComputerName localhost `
+                            -Wait `
+                            -Verbose `
+                            -Force `
+                            -ErrorAction Stop
+                    } | Should -Not -Throw
+                }
+
+                It 'should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+                }
+
+                It 'Should have set the resource and all the parameters should match' {
+                    $current = Get-DscConfiguration | Where-Object -FilterScript {
+                        $_.ConfigurationName -eq "$($script:dscResourceName)_Config"
+                    }
+                    $current.InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
+                    $current.AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
+                    $current.IPAddress | Should -Be $configData.AllNodes[0].IPAddress
+                }
+            }
+        }
+
+        Context 'When a two IP addresses are specified' {
             It 'Should compile and apply the MOF without throwing' {
                 {
-                    & "$($script:dscResourceName)_Config" -OutputPath $TestDrive
+                    # This is to pass to the Config
+                    $configData = @{
+                        AllNodes = @(
+                            @{
+                                NodeName       = 'localhost'
+                                InterfaceAlias = 'NetworkingDscLBA2'
+                                AddressFamily  = 'IPv4'
+                                IPAddress      = @('10.12.13.14/16', '10.13.14.16/32')
+                            }
+                        )
+                    }
+
+                    & "$($script:dscResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
 
                     Start-DscConfiguration `
                         -Path $TestDrive `
@@ -52,13 +111,10 @@ try
                 $current = Get-DscConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq "$($script:dscResourceName)_Config"
                 }
-                $current[0].InterfaceAlias | Should -Be $TestIPAddress.InterfaceAlias
-                $current[0].AddressFamily  | Should -Be $TestIPAddress.AddressFamily
-                $current[0].IPAddress      | Should -Be $TestIPAddress.IPAddress
-                $current[1].InterfaceAlias | Should -Be $TestMultipleIPAddress.InterfaceAlias
-                $current[1].AddressFamily  | Should -Be $TestMultipleIPAddress.AddressFamily
-                $current[1].IPAddress      | Should -Contain $TestMultipleIPAddress.IPAddress[0]
-                $current[1].IPAddress      | Should -Contain $TestMultipleIPAddress.IPAddress[1]
+                $current.InterfaceAlias | Should -Be $configData.AllNodes[0].InterfaceAlias
+                $current.AddressFamily | Should -Be $configData.AllNodes[0].AddressFamily
+                $current.IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[0]
+                $current.IPAddress | Should -Contain $configData.AllNodes[0].IPAddress[1]
             }
         }
     }

--- a/tests/Integration/DSC_IPAddress.config.ps1
+++ b/tests/Integration/DSC_IPAddress.config.ps1
@@ -1,14 +1,3 @@
-$TestIPAddress = [PSObject]@{
-    InterfaceAlias          = 'NetworkingDscLBA'
-    AddressFamily           = 'IPv4'
-    IPAddress               = '10.11.12.13/16'
-}
-$TestMultipleIPAddress = [PSObject]@{
-    InterfaceAlias          = 'NetworkingDscLBA2'
-    AddressFamily           = 'IPv4'
-    IPAddress               = @('10.12.13.14/16','10.13.14.16/32')
-}
-
 configuration DSC_IPAddress_Config {
     Import-DscResource -ModuleName NetworkingDsc
 
@@ -17,11 +6,6 @@ configuration DSC_IPAddress_Config {
             InterfaceAlias          = $TestIPAddress.InterfaceAlias
             AddressFamily           = $TestIPAddress.AddressFamily
             IPAddress               = $TestIPAddress.IPAddress
-        }
-        IPAddress Integration_Test2 {
-            InterfaceAlias          = $TestMultipleIPAddress.InterfaceAlias
-            AddressFamily           = $TestMultipleIPAddress.AddressFamily
-            IPAddress               = $TestMultipleIPAddress.IPAddress
         }
     }
 }

--- a/tests/Integration/DSC_IPAddress.config.ps1
+++ b/tests/Integration/DSC_IPAddress.config.ps1
@@ -3,9 +3,9 @@ configuration DSC_IPAddress_Config {
 
     node localhost {
         IPAddress Integration_Test {
-            InterfaceAlias          = $TestIPAddress.InterfaceAlias
-            AddressFamily           = $TestIPAddress.AddressFamily
-            IPAddress               = $TestIPAddress.IPAddress
+            InterfaceAlias          = $Node.InterfaceAlias
+            AddressFamily           = $Node.AddressFamily
+            IPAddress               = $Node.IPAddress
         }
     }
 }

--- a/tests/Unit/DSC_NetIPInterface.Tests.ps1
+++ b/tests/Unit/DSC_NetIPInterface.Tests.ps1
@@ -46,7 +46,7 @@ try
         $testParameterList = @(
             @{
                 Name            = 'AdvertiseDefaultRoute'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.AdvertiseDefaultRoute]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $AdvertiseDefaultRoute -eq 'Disabled'
@@ -54,7 +54,7 @@ try
             },
             @{
                 Name            = 'Advertising'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.Advertising]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $Advertising -eq 'Disabled'
@@ -62,7 +62,7 @@ try
             },
             @{
                 Name            = 'AutomaticMetric'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.AutomaticMetric]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $AutomaticMetric -eq 'Disabled'
@@ -70,7 +70,7 @@ try
             },
             @{
                 Name            = 'Dhcp'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.Dhcp]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $Dhcp -eq 'Disabled'
@@ -78,7 +78,7 @@ try
             },
             @{
                 Name            = 'DirectedMacWolPattern'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.DirectedMacWolPattern]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $DirectedMacWolPattern -eq 'Disabled'
@@ -86,7 +86,7 @@ try
             },
             @{
                 Name            = 'EcnMarking'
-                MockedValue     = 'AppDecide'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.EcnMarking]::AppDecide
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $EcnMarking -eq 'Disabled'
@@ -94,7 +94,7 @@ try
             },
             @{
                 Name            = 'ForceArpNdWolPattern'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.ForceArpNdWolPattern]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $ForceArpNdWolPattern -eq 'Disabled'
@@ -102,7 +102,7 @@ try
             },
             @{
                 Name            = 'Forwarding'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.Forwarding]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $Forwarding -eq 'Disabled'
@@ -110,7 +110,7 @@ try
             },
             @{
                 Name            = 'IgnoreDefaultRoutes'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.IgnoreDefaultRoutes]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $IgnoreDefaultRoutes -eq 'Disabled'
@@ -118,7 +118,7 @@ try
             },
             @{
                 Name            = 'ManagedAddressConfiguration'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.ManagedAddressConfiguration]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $ManagedAddressConfiguration -eq 'Disabled'
@@ -126,7 +126,7 @@ try
             },
             @{
                 Name            = 'NeighborUnreachabilityDetection'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.NeighborUnreachabilityDetection]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $NeighborUnreachabilityDetection -eq 'Disabled'
@@ -134,7 +134,7 @@ try
             },
             @{
                 Name            = 'OtherStatefulConfiguration'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.OtherStatefulConfiguration]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $OtherStatefulConfiguration -eq 'Disabled'
@@ -142,7 +142,7 @@ try
             },
             @{
                 Name            = 'RouterDiscovery'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.RouterDiscovery]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $RouterDiscovery -eq 'Disabled'
@@ -150,7 +150,7 @@ try
             },
             @{
                 Name            = 'WeakHostReceive'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.WeakHostReceive]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $WeakHostReceive -eq 'Disabled'
@@ -158,7 +158,7 @@ try
             },
             @{
                 Name            = 'WeakHostSend'
-                MockedValue     = 'Enabled'
+                MockedValue     = [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetIPInterface.WeakHostSend]::Enabled
                 TestValue       = 'Disabled'
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $WeakHostSend -eq 'Disabled'
@@ -370,7 +370,7 @@ try
                 }
             }
         }
-    } #end InModuleScope $DSCResourceName
+    }
 }
 finally
 {


### PR DESCRIPTION
#### Pull Request (PR) description

  - Fix 'type mismatch for property' issue when setting 'AdvertiseDefaultRoute',
    'Advertising', 'AutomaticMetric', 'Dhcp', 'DirectedMacWolPattern', 'EcnMarking',
    'ForceArpNdWolPattern', 'Forwarding', 'IgnoreDefaultRoutes', 'ManagedAddressConfiguration',
    'NeighborUnreachabilityDetection', 'OtherStatefulConfiguration', 'RouterDiscovery',
    'WeakHostReceive' or 'WeakHostSend' - Fixes [Issue #470](https://github.com/dsccommunity/NetworkingDsc/issues/470).

#### This Pull Request (PR) fixes the following issues

- Fixes #470 

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/networkingdsc/471)
<!-- Reviewable:end -->
