### PR TITLE
InterfaceMetric: Configure a static metric for an IPv4 Interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IPAddress
   - Improved integration test structure.
 
+### Added
+
+- NetIPInterface
+  - Added `InterfaceMetric` parameter.
+
 ### Fixed
 
 - NetIPInterface

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.data.psd1
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.data.psd1
@@ -68,6 +68,5 @@
             ParameterName = 'InterfaceMetric'
             PropertyName = 'InterfaceMetric'
         }
-        }
     )
 }

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.data.psd1
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.data.psd1
@@ -63,6 +63,11 @@
         @{
             ParameterName = 'NlMtuBytes'
             PropertyName = 'NlMtu'
+        },
+        @{
+            ParameterName = 'InterfaceMetric'
+            PropertyName = 'InterfaceMetric'
+        }
         }
     )
 }

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
@@ -118,6 +118,9 @@ function Get-TargetResource
 
     .PARAMETER NlMtu
         Specifies the network layer Maximum Transmission Unit (MTU) value, in bytes, for an IP interface.
+
+    .PARAMETER InterfaceMetric
+        Specifies the metric for an IP interface.
 #>
 function Set-TargetResource
 {
@@ -211,7 +214,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $NlMtu
+        $NlMtu,
+
+        [Parameter()]
+        [System.UInt32]
+        $InterfaceMetric
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -322,6 +329,9 @@ function Set-TargetResource
 
     .PARAMETER NlMtu
         Specifies the network layer Maximum Transmission Unit (MTU) value, in bytes, for an IP interface.
+
+    .PARAMETER InterfaceMetric
+        Specifies the metric for an IP interface.
 #>
 function Test-TargetResource
 {
@@ -416,7 +426,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.UInt32]
-        $NlMtu
+        $NlMtu,
+
+        [Parameter()]
+        [System.UInt32]
+        $InterfaceMetric
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.schema.mof
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.schema.mof
@@ -19,4 +19,5 @@ class DSC_NetIPInterface : OMI_BaseResource
     [Write, Description("Specifies the receive value for a weak host model."), ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] String WeakHostReceive;
     [Write, Description("Specifies the send value for a weak host model."), ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] String WeakHostSend;
     [Write, Description("Specifies the network layer Maximum Transmission Unit (MTU) value, in bytes, for an IP interface.")] UInt32 NlMtu;
+    [Write, Description("Specifies the metric for an IP interface.")] UInt32 InterfaceMetric;
 };

--- a/source/DSCResources/DSC_NetIPInterface/README.MD
+++ b/source/DSCResources/DSC_NetIPInterface/README.MD
@@ -1,3 +1,7 @@
 # Description
 
 This resource is used to configure the IP interface settings for a network interface.
+
+## Known Issues
+
+- If you define a value for `InterfaceMetric`, the `AutomaticMetric` setting is ignored.  PowerShell ignores `AutomaticMetric` when you use both arguments with the   `Set-NetIPInterface` cmdlet.

--- a/source/DSCResources/DSC_NetIPInterface/README.MD
+++ b/source/DSCResources/DSC_NetIPInterface/README.MD
@@ -5,5 +5,5 @@ This resource is used to configure the IP interface settings for a network inter
 ## Known Issues
 
 - If you define a value for `InterfaceMetric`, the `AutomaticMetric`
- setting is ignored. PowerShell ignores `AutomaticMetric` when you
- use both arguments with the `Set-NetIPInterface` cmdlet.
+setting is ignored. PowerShell ignores `AutomaticMetric` when you
+use both arguments with the `Set-NetIPInterface` cmdlet.

--- a/source/DSCResources/DSC_NetIPInterface/README.MD
+++ b/source/DSCResources/DSC_NetIPInterface/README.MD
@@ -6,4 +6,4 @@ This resource is used to configure the IP interface settings for a network inter
 
 - If you define a value for `InterfaceMetric`, the `AutomaticMetric`
  setting is ignored. PowerShell ignores `AutomaticMetric` when you
- use both arguments with the   `Set-NetIPInterface` cmdlet.
+ use both arguments with the `Set-NetIPInterface` cmdlet.

--- a/source/DSCResources/DSC_NetIPInterface/README.MD
+++ b/source/DSCResources/DSC_NetIPInterface/README.MD
@@ -4,4 +4,6 @@ This resource is used to configure the IP interface settings for a network inter
 
 ## Known Issues
 
-- If you define a value for `InterfaceMetric`, the `AutomaticMetric` setting is ignored.  PowerShell ignores `AutomaticMetric` when you use both arguments with the   `Set-NetIPInterface` cmdlet.
+- If you define a value for `InterfaceMetric`, the `AutomaticMetric`
+ setting is ignored. PowerShell ignores `AutomaticMetric` when you
+ use both arguments with the   `Set-NetIPInterface` cmdlet.

--- a/source/Examples/Resources/NetIPInterface/4-NetIPInterface_SetInterfaceMetric.ps1
+++ b/source/Examples/Resources/NetIPInterface/4-NetIPInterface_SetInterfaceMetric.ps1
@@ -1,0 +1,46 @@
+<#PSScriptInfo
+.VERSION 1.0.0
+.GUID c67b7df4-bafa-4bca-bb43-349b44df3530
+.AUTHOR DSC Community
+.COMPANYNAME DSC Community
+.COPYRIGHT Copyright the DSC Community contributors. All rights reserved.
+.TAGS DSCConfiguration
+.LICENSEURI https://github.com/dsccommunity/NetworkingDsc/blob/master/LICENSE
+.PROJECTURI https://github.com/dsccommunity/NetworkingDsc
+.ICONURI
+.EXTERNALMODULEDEPENDENCIES
+.REQUIREDSCRIPTS
+.EXTERNALSCRIPTDEPENDENCIES
+.RELEASENOTES First version.
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+#>
+
+#Requires -module NetworkingDsc
+
+<#
+    .DESCRIPTION
+    Set a specified interface metrics for the network adapters with alias 'Ethernet' and 'Ethernet 2'.
+#>
+Configuration NetIPInterface_InterfaceMetric_Config
+{
+    Import-DscResource -Module NetworkingDsc
+
+    Node localhost
+    {
+        NetIPInterface EthernetMetric
+        {
+            InterfaceAlias  = 'Ethernet'
+            AddressFamily   = 'IPv4'
+            AutomaticMetric = 'Disabled'
+            InterfaceMetric = 10
+        }
+
+        NetIPInterface Ethernet2Metric
+        {
+            InterfaceAlias  = 'Ethernet 2'
+            AddressFamily   = 'IPv4'
+            AutomaticMetric = 'Disabled'
+            InterfaceMetric = 20
+        }
+    }
+}

--- a/source/Examples/Resources/NetIPInterface/5-NetIPInterface_SetInterfaceMetric.ps1
+++ b/source/Examples/Resources/NetIPInterface/5-NetIPInterface_SetInterfaceMetric.ps1
@@ -21,7 +21,7 @@
     .DESCRIPTION
     Set a specified interface metrics for the network adapters with alias 'Ethernet' and 'Ethernet 2'.
 #>
-Configuration NetIPInterface_InterfaceMetric_Config
+Configuration NetIPInterface_SetInterfaceMetric
 {
     Import-DscResource -Module NetworkingDsc
 

--- a/tests/Integration/DSC_NetIPInterface.Integration.Tests.ps1
+++ b/tests/Integration/DSC_NetIPInterface.Integration.Tests.ps1
@@ -136,6 +136,7 @@ try
                             InterfaceAlias              = 'NetworkingDscLBA'
                             AddressFamily               = 'IPv4'
                             AdvertiseDefaultRoute       = 'Disabled'
+                            AutomaticMetric             = 'Disabled'
                             Dhcp                        = 'Disabled'
                             DirectedMacWolPattern       = 'Disabled'
                             EcnMarking                  = 'Disabled'
@@ -148,6 +149,7 @@ try
                             WeakHostReceive             = 'Disabled'
                             WeakHostSend                = 'Disabled'
                             NlMtu                       = 1500
+                            InterfaceMetric             = 20
                         }
                     )
                 }
@@ -179,6 +181,7 @@ try
                     $current.InterfaceAlias                  | Should -Be $script:configData.AllNodes[0].InterfaceAlias
                     $current.AddressFamily                   | Should -Be $script:configData.AllNodes[0].AddressFamily
                     $current.AdvertiseDefaultRoute           | Should -Be $script:configData.AllNodes[0].AdvertiseDefaultRoute
+                    $current.AutomaticMetric                 | Should -Be $script:configData.AllNodes[0].AutomaticMetric
                     $current.Dhcp                            | Should -Be $script:configData.AllNodes[0].Dhcp
                     $current.DirectedMacWolPattern           | Should -Be $script:configData.AllNodes[0].DirectedMacWolPattern
                     $current.EcnMarking                      | Should -Be $script:configData.AllNodes[0].EcnMarking
@@ -191,6 +194,7 @@ try
                     $current.WeakHostReceive                 | Should -Be $script:configData.AllNodes[0].WeakHostReceive
                     $current.WeakHostSend                    | Should -Be $script:configData.AllNodes[0].WeakHostSend
                     $current.NlMtu                           | Should -Be $script:configData.AllNodes[0].NlMtu
+                    $current.InterfaceMetric                 | Should -Be $script:configData.AllNodes[0].InterfaceMetric
                 }
             }
         }

--- a/tests/Integration/DSC_NetIPInterface.config.ps1
+++ b/tests/Integration/DSC_NetIPInterface.config.ps1
@@ -21,6 +21,7 @@ configuration DSC_NetIPInterface_Config_Enabled {
             WeakHostReceive                 = $Node.WeakHostReceive
             WeakHostSend                    = $Node.WeakHostSend
             NlMtu                           = $Node.NlMtu
+            InterfaceMetric                 = $Node.InterfaceMetric
         }
     }
 }
@@ -46,6 +47,7 @@ configuration DSC_NetIPInterface_Config_Disabled {
             WeakHostReceive                 = $Node.WeakHostReceive
             WeakHostSend                    = $Node.WeakHostSend
             NlMtu                           = $Node.NlMtu
+            InterfaceMetric                 = $Node.InterfaceMetric
         }
     }
 }

--- a/tests/Unit/DSC_NetIPInterface.Tests.ps1
+++ b/tests/Unit/DSC_NetIPInterface.Tests.ps1
@@ -171,6 +171,14 @@ try
                 ParameterFilter = {
                     $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $NlMtuBytes -eq 1500
                 }
+            },
+            @{
+                Name            = 'InterfaceMetric'
+                MockedValue     = [System.Uint32] 20
+                TestValue       = [System.Uint32] 15
+                ParameterFilter = {
+                    $InterfaceAlias -eq 'Ethernet' -and $AddressFamily -eq 'IPv4' -and $InterfaceMetric -eq 15
+                }
             }
         )
 


### PR DESCRIPTION
#### Pull Request (PR) description
Adds InterfaceMetric to NetIPInterface to statically configure a metric on an IPv4 interface.  I need this for multi-homed computers to give preference to one interface over another.

#### This Pull Request (PR) fixes the following issues

- Fixes #391 
- Fixes #473 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in README.md in resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/networkingdsc/472)
<!-- Reviewable:end -->
