### PR TITLE
Allow configuration of hidden network adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #489](https://github.com/dsccommunity/NetworkingDsc/issues/489).
 - Added support for publishing code coverage to `CodeCov.io` and
   Azure Pipelines - Fixes [Issue #491](https://github.com/dsccommunity/NetworkingDsc/issues/491).
-- Minor reformatting of code style for diffability.
+- Allow configuration of hidden network adapters.
 
 ## [8.2.0] - 2020-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #489](https://github.com/dsccommunity/NetworkingDsc/issues/489).
 - Added support for publishing code coverage to `CodeCov.io` and
   Azure Pipelines - Fixes [Issue #491](https://github.com/dsccommunity/NetworkingDsc/issues/491).
+- Minor reformatting of code style for diffability.
 
 ## [8.2.0] - 2020-10-16
 

--- a/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
+++ b/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
@@ -292,7 +292,7 @@ function Assert-ResourceProperty
         $Address
     )
 
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Find-NetworkAdapter -Name $InterfaceAlias ))
     {
         New-InvalidOperationException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias)

--- a/source/DSCResources/DSC_DnsConnectionSuffix/DSC_DnsConnectionSuffix.psm1
+++ b/source/DSCResources/DSC_DnsConnectionSuffix/DSC_DnsConnectionSuffix.psm1
@@ -60,7 +60,9 @@ function Get-TargetResource
         $Ensure = 'Present'
     )
 
-    $dnsClient = Get-DnsClient -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+    $dnsClient = Get-DnsClient `
+        -InterfaceAlias $InterfaceAlias `
+        -ErrorAction SilentlyContinue
 
     $targetResource = @{
         InterfaceAlias                 = $dnsClient.InterfaceAlias

--- a/source/DSCResources/DSC_FirewallProfile/DSC_FirewallProfile.psm1
+++ b/source/DSCResources/DSC_FirewallProfile/DSC_FirewallProfile.psm1
@@ -245,7 +245,10 @@ function Set-TargetResource
         $parameterNewValue = (Get-Variable -Name ($parameter.name)).Value
 
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
-            -and (Compare-Object -ReferenceObject $parameterSourceValue -DifferenceObject $parameterNewValue -SyncWindow 0))
+            -and (Compare-Object `
+                -ReferenceObject $parameterSourceValue `
+                -DifferenceObject $parameterNewValue `
+                -SyncWindow 0))
         {
             $changeParameters += @{
                 $($parameter.name) = $parameterNewValue

--- a/source/DSCResources/DSC_FirewallProfile/DSC_FirewallProfile.psm1
+++ b/source/DSCResources/DSC_FirewallProfile/DSC_FirewallProfile.psm1
@@ -46,7 +46,8 @@ function Get-TargetResource
         ) -join '' )
 
     # Get the current Dns Client Global Settings
-    $netFirewallProfile = Get-NetFirewallProfile -Name $Name `
+    $netFirewallProfile = Get-NetFirewallProfile `
+        -Name $Name `
         -ErrorAction Stop
 
     # Generate the return object.
@@ -231,7 +232,8 @@ function Set-TargetResource
         ) -join '' )
 
     # Get the current Firewall Profile Settings
-    $netFirewallProfile = Get-NetFirewallProfile -Name $Name `
+    $netFirewallProfile = Get-NetFirewallProfile `
+        -Name $Name `
         -ErrorAction Stop
 
     # Generate a list of parameters that will need to be changed.
@@ -442,7 +444,8 @@ function Test-TargetResource
     $desiredConfigurationMatch = $true
 
     # Get the current Dns Client Global Settings
-    $netFirewallProfile = Get-NetFirewallProfile -Name $Name `
+    $netFirewallProfile = Get-NetFirewallProfile `
+        -Name $Name `
         -ErrorAction Stop
 
     # Check each parameter

--- a/source/DSCResources/DSC_IPAddress/DSC_IPAddress.psm1
+++ b/source/DSCResources/DSC_IPAddress/DSC_IPAddress.psm1
@@ -228,7 +228,8 @@ function Set-TargetResource
         try
         {
             # Apply the specified IP configuration
-            New-NetIPAddress @newNetIPAddressParameters -ErrorAction Stop
+            New-NetIPAddress @newNetIPAddressParameters `
+                -ErrorAction Stop
         }
         catch [Microsoft.Management.Infrastructure.CimException]
         {
@@ -240,7 +241,8 @@ function Set-TargetResource
                 Setting New-NetIPaddress will throw [Microsoft.Management.Infrastructure.CimException] if
                 the IP address is already set. Need to check to make sure the IP is set on correct interface
             #>
-            $verifyNetIPAddressAdapter = Get-NetIPAddress @verifyNetIPAddressAdapterParam -ErrorAction SilentlyContinue
+            $verifyNetIPAddressAdapter = Get-NetIPAddress @verifyNetIPAddressAdapterParam `
+                -ErrorAction SilentlyContinue
 
             if ($verifyNetIPAddressAdapter.InterfaceAlias -eq $InterfaceAlias)
             {
@@ -343,7 +345,9 @@ function Test-TargetResource
         }
     } # while
 
-    $ipAddressObject = Get-IPAddressPrefix -IPAddress $IPAddress -AddressFamily $AddressFamily
+    $ipAddressObject = Get-IPAddressPrefix `
+        -IPAddress $IPAddress `
+        -AddressFamily $AddressFamily
 
     # Test if the IP Address passed is present
     foreach ($singleIP in $ipAddressObject)
@@ -480,7 +484,9 @@ function Assert-ResourceProperty
     {
         $singleIP = ($singleIPAddress -split '/')[0]
 
-        Assert-IPAddress -Address $singleIP -AddressFamily $AddressFamily
+        Assert-IPAddress `
+            -Address $singleIP `
+            -AddressFamily $AddressFamily
     }
 
     foreach ($prefixLength in $prefixLengthArray)

--- a/source/DSCResources/DSC_IPAddressOption/DSC_IPAddressOption.psm1
+++ b/source/DSCResources/DSC_IPAddressOption/DSC_IPAddressOption.psm1
@@ -83,7 +83,9 @@ function Set-TargetResource
 
     if ($currentConfig.SkipAsSource -ne $SkipAsSource)
     {
-        Set-NetIPAddress -IPAddress $IPAddress -SkipAsSource $SkipAsSource
+        Set-NetIPAddress `
+            -IPAddress $IPAddress `
+            -SkipAsSource $SkipAsSource
     }
 }
 

--- a/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.psm1
+++ b/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.psm1
@@ -51,6 +51,7 @@ function Get-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$true `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }
@@ -118,6 +119,7 @@ function Set-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$true `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }
@@ -146,6 +148,7 @@ function Set-TargetResource
             Set-NetAdapterAdvancedProperty `
                 -RegistryValue $RegistryValue `
                 -Name $networkAdapterName `
+                -IncludeHidden:$true `
                 -RegistryKeyword $RegistryKeyword
         }
     }
@@ -192,6 +195,7 @@ function Test-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$true `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }

--- a/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
+++ b/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
@@ -262,7 +262,7 @@ function Get-Binding
         $State = 'Enabled'
     )
 
-    if (-not (Get-NetAdapter -Name $InterfaceAlias -ErrorAction SilentlyContinue))
+    if (-not (Find-NetworkAdapter -Name $InterfaceAlias -ErrorAction SilentlyContinue))
     {
         New-InvalidArgumentException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias) `

--- a/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
+++ b/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
@@ -126,7 +126,8 @@ function Set-TargetResource
 
     if ($State -eq 'Enabled')
     {
-        Enable-NetAdapterBinding @PSBoundParameters
+        Enable-NetAdapterBinding @PSBoundParameters `
+            -IncludeHidden:$true
 
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
                 $($script:localizedData.NetAdapterBindingEnabledMessage -f `
@@ -135,7 +136,8 @@ function Set-TargetResource
     }
     else
     {
-        Disable-NetAdapterBinding @PSBoundParameters
+        Disable-NetAdapterBinding @PSBoundParameters `
+            -IncludeHidden:$true
 
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
                 $($script:localizedData.NetAdapterBindingDisabledMessage -f `
@@ -269,6 +271,7 @@ function Get-Binding
 
     $binding = Get-NetAdapterBinding `
         -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$true `
         -ComponentId $ComponentId `
         -ErrorAction Stop
 

--- a/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
+++ b/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
@@ -50,7 +50,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -131,7 +133,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -154,7 +158,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.V1IPv4Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -V1IPv4Enabled $State
+            Set-NetAdapterLso `
+                -Name $Name `
+                -V1IPv4Enabled $State
         }
         elseif ($Protocol -eq 'IPv4' -and $State -ne $netAdapter.IPv4Enabled)
         {
@@ -164,7 +170,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv4Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -IPv4Enabled $State
+            Set-NetAdapterLso `
+                -Name $Name `
+                -IPv4Enabled $State
         }
         elseif ($Protocol -eq 'IPv6' -and $State -ne $netAdapter.IPv6Enabled)
         {
@@ -174,7 +182,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv6Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -IPv6Enabled $State
+            Set-NetAdapterLso `
+                -Name $Name `
+                -IPv6Enabled $State
         }
     }
 }
@@ -219,7 +229,9 @@ function Test-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
+++ b/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
@@ -52,6 +52,7 @@ function Get-TargetResource
     {
         $netAdapter = Get-NetAdapterLso `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -135,6 +136,7 @@ function Set-TargetResource
     {
         $netAdapter = Get-NetAdapterLso `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -160,6 +162,7 @@ function Set-TargetResource
 
             Set-NetAdapterLso `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -V1IPv4Enabled $State
         }
         elseif ($Protocol -eq 'IPv4' -and $State -ne $netAdapter.IPv4Enabled)
@@ -172,6 +175,7 @@ function Set-TargetResource
 
             Set-NetAdapterLso `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -IPv4Enabled $State
         }
         elseif ($Protocol -eq 'IPv6' -and $State -ne $netAdapter.IPv6Enabled)
@@ -184,6 +188,7 @@ function Set-TargetResource
 
             Set-NetAdapterLso `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -IPv6Enabled $State
         }
     }
@@ -231,6 +236,7 @@ function Test-TargetResource
     {
         $netAdapter = Get-NetAdapterLso `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
@@ -253,7 +253,8 @@ function Set-TargetResource
             $($script:localizedData.RenamingNetAdapterNameMessage -f $adapter.Name, $NewName)
         ) -join '')
 
-    $adapter | Rename-NetAdapter -NewName $NewName
+    $adapter | Rename-NetAdapter `
+        -NewName $NewName
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($script:localizedData.NetAdapterNameRenamedMessage -f $NewName)

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
@@ -33,6 +33,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER InterfaceDescription
         This is the interface description of the network adapter to find.
 
+    .PARAMETER IncludeHidden
+        This switch indicates the adapter to find may be hidden.
+
     .PARAMETER InterfaceIndex
         This is the interface index of the network adapter to find.
 
@@ -85,6 +88,10 @@ function Get-TargetResource
         $InterfaceDescription,
 
         [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
         [System.UInt32]
         $InterfaceIndex,
 
@@ -111,6 +118,7 @@ function Get-TargetResource
 
     $adapter = Find-NetworkAdapter `
         -Name $NewName `
+        -IncludeHidden:$IncludeHidden `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)
@@ -136,6 +144,7 @@ function Get-TargetResource
         Status                         = $adapter.Status
         MacAddress                     = $adapter.MacAddress
         InterfaceDescription           = $adapter.InterfaceDescription
+        IncludeHidden                  = $IncludeHidden
         InterfaceIndex                 = $adapter.InterfaceIndex
         InterfaceGuid                  = $adapter.InterfaceGuid
         DriverDescription              = $adapter.DriverDescription
@@ -167,6 +176,9 @@ function Get-TargetResource
 
     .PARAMETER InterfaceDescription
         This is the interface description of the network adapter to find.
+
+    .PARAMETER IncludeHidden
+        This switch indicates the adapter to find may be hidden.
 
     .PARAMETER InterfaceIndex
         This is the interface index of the network adapter to find.
@@ -219,6 +231,10 @@ function Set-TargetResource
         $InterfaceDescription,
 
         [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
         [System.UInt32]
         $InterfaceIndex,
 
@@ -254,6 +270,7 @@ function Set-TargetResource
         ) -join '')
 
     $adapter | Rename-NetAdapter `
+        -IncludeHidden:$IncludeHidden `
         -NewName $NewName
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -283,6 +300,9 @@ function Set-TargetResource
 
     .PARAMETER InterfaceDescription
         This is the interface description of the network adapter to find.
+
+    .PARAMETER IncludeHidden
+        This switch indicates the adapter to find may be hidden.
 
     .PARAMETER InterfaceIndex
         This is the interface index of the network adapter to find.
@@ -336,6 +356,10 @@ function Test-TargetResource
         $InterfaceDescription,
 
         [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
         [System.UInt32]
         $InterfaceIndex,
 
@@ -365,6 +389,7 @@ function Test-TargetResource
     # Can an adapter be found with the new name?
     $adapterWithNewName = Find-NetworkAdapter `
         -Name $NewName `
+        -IncludeHidden:$IncludeHidden `
         -Verbose:$Verbose `
         -ErrorAction SilentlyContinue
 

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
@@ -7,6 +7,7 @@ class DSC_NetAdapterName : OMI_BaseResource
     [Write, Description("This is the status of the network adapter to find."), ValueMap{"Up", "Disconnected", "Disabled"}, Values{"Up", "Disconnected", "Disabled"}] String Status;
     [Write, Description("This is the MAC address of the network adapter to find.")] String MacAddress;
     [Write, Description("This is the interface description of the network adapter to find.")] String InterfaceDescription;
+    [Write, Description("This switch indicates the adapter to find may be hidden.")] Boolean IncludeHidden;
     [Write, Description("This is the interface index of the network adapter to find.")] UInt32 InterfaceIndex;
     [Write, Description("This is the interface GUID of the network adapter to find.")] String InterfaceGuid;
     [Write, Description("This is the driver description of the network adapter.")] String DriverDescription;

--- a/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
+++ b/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
@@ -37,7 +37,9 @@ function Get-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -85,7 +87,9 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -101,7 +105,9 @@ function Set-TargetResource
         {
             Write-Verbose -Message ($script:localizedData.SetNetAdapterRdmaMessage -f $Name, $Enabled)
 
-            Set-NetAdapterRdma -Name $Name -Enabled $Enabled
+            Set-NetAdapterRdma `
+                -Name $Name `
+                -Enabled $Enabled
         }
     }
 }
@@ -137,7 +143,9 @@ function Test-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
+++ b/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
@@ -39,6 +39,7 @@ function Get-TargetResource
 
         $netAdapterRdma = Get-NetAdapterRdma `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -89,6 +90,7 @@ function Set-TargetResource
 
         $netAdapterRdma = Get-NetAdapterRdma `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -107,6 +109,7 @@ function Set-TargetResource
 
             Set-NetAdapterRdma `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -Enabled $Enabled
         }
     }

--- a/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
+++ b/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
@@ -52,6 +52,7 @@ function Get-TargetResource
     {
         $netAdapter = Get-NetAdapterRsc `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -136,6 +137,7 @@ function Set-TargetResource
     {
         $netAdapter = Get-NetAdapterRsc `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -161,6 +163,7 @@ function Set-TargetResource
 
             Set-NetAdapterRsc `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -IPv4Enabled $State
         }
         if ($Protocol -in ('IPv6', 'All') -and $State -ne $netAdapter.IPv6Enabled)
@@ -173,6 +176,7 @@ function Set-TargetResource
 
             Set-NetAdapterRsc `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -IPv6Enabled $State
         }
     }
@@ -220,6 +224,7 @@ function Test-TargetResource
     {
         $netAdapter = Get-NetAdapterRsc `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch

--- a/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
+++ b/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
@@ -50,7 +50,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRsc -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRsc `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -132,7 +134,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRsc -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRsc `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -155,7 +159,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv4Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterRsc -Name $Name -IPv4Enabled $State
+            Set-NetAdapterRsc `
+                -Name $Name `
+                -IPv4Enabled $State
         }
         if ($Protocol -in ('IPv6', 'All') -and $State -ne $netAdapter.IPv6Enabled)
         {
@@ -165,7 +171,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv6Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterRsc -Name $Name -IPv6Enabled $State
+            Set-NetAdapterRsc `
+                -Name $Name `
+                -IPv6Enabled $State
         }
     }
 }
@@ -210,7 +218,9 @@ function Test-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRsc -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRsc `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
+++ b/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
@@ -42,7 +42,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -97,7 +99,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -120,7 +124,9 @@ function Set-TargetResource
                             $Name, $Enabled, $($netAdapter.Enabled.ToString()), $($Enabled.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterRss -Name $Name -Enabled:$Enabled
+            Set-NetAdapterRss `
+                -Name $Name `
+                -Enabled:$Enabled
         }
     }
 }
@@ -157,7 +163,9 @@ function Test-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
+++ b/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
@@ -44,6 +44,7 @@ function Get-TargetResource
     {
         $netAdapter = Get-NetAdapterRss `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -101,6 +102,7 @@ function Set-TargetResource
     {
         $netAdapter = Get-NetAdapterRss `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch
@@ -126,6 +128,7 @@ function Set-TargetResource
 
             Set-NetAdapterRss `
                 -Name $Name `
+                -IncludeHidden:$true `
                 -Enabled:$Enabled
         }
     }
@@ -165,6 +168,7 @@ function Test-TargetResource
     {
         $netAdapter = Get-NetAdapterRss `
             -Name $Name `
+            -IncludeHidden:$true `
             -ErrorAction Stop
     }
     catch

--- a/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
+++ b/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
@@ -137,6 +137,7 @@ function Set-TargetResource
             {
                 Disable-NetAdapter `
                     -Name $Name `
+                    -IncludeHidden:$true `
                     -Confirm:$false `
                     -ErrorAction Stop
             }
@@ -144,6 +145,7 @@ function Set-TargetResource
             {
                 Enable-NetAdapter `
                     -Name $Name `
+                    -IncludeHidden:$true `
                     -ErrorAction Stop
             }
         }

--- a/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
+++ b/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
@@ -44,7 +44,7 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter `
+        $netAdapter = Find-NetworkAdapter `
             -Name $Name `
             -ErrorAction Stop
     }
@@ -117,7 +117,7 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter `
+        $netAdapter = Find-NetworkAdapter `
             -Name $Name `
             -ErrorAction Stop
     }

--- a/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
+++ b/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
@@ -44,7 +44,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapter `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -115,7 +117,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapter `
+            -Name $Name `
+            -ErrorAction Stop
     }
     catch
     {
@@ -131,11 +135,16 @@ function Set-TargetResource
         {
             if ($State -eq 'Disabled')
             {
-                Disable-NetAdapter -Name $Name -Confirm:$false -ErrorAction Stop
+                Disable-NetAdapter `
+                    -Name $Name `
+                    -Confirm:$false `
+                    -ErrorAction Stop
             }
             else
             {
-                Enable-NetAdapter -Name $Name -ErrorAction Stop
+                Enable-NetAdapter `
+                    -Name $Name `
+                    -ErrorAction Stop
             }
         }
         catch

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -92,7 +92,9 @@ function Get-TargetResource
 
         foreach ($netAdapterItem in $netAdapter)
         {
-            $settingResults += Get-NetAdapterNetbiosOptionsFromRegistry -NetworkAdapterGUID $netAdapterItem.GUID -Setting $Setting
+            $settingResults += Get-NetAdapterNetbiosOptionsFromRegistry `
+                -NetworkAdapterGUID $netAdapterItem.GUID `
+                -Setting $Setting
 
             Write-Verbose -Message ($script:localizedData.CurrentNetBiosSettingMessage -f $netAdapterItem.NetConnectionID, $settingResults[-1])
         }
@@ -108,7 +110,9 @@ function Get-TargetResource
     }
     else
     {
-        $Setting = Get-NetAdapterNetbiosOptionsFromRegistry -NetworkAdapterGUID $netAdapter.GUID -Setting $Setting
+        $Setting = Get-NetAdapterNetbiosOptionsFromRegistry `
+            -NetworkAdapterGUID $netAdapter.GUID `
+            -Setting $Setting
     }
 
     Write-Verbose -Message ($script:localizedData.CurrentNetBiosSettingMessage -f $InterfaceAlias, $Setting)
@@ -167,7 +171,9 @@ function Set-TargetResource
     {
         foreach ($netAdapterItem in $netAdapter)
         {
-            $currentValue = Get-NetAdapterNetbiosOptionsFromRegistry -NetworkAdapterGUID $netAdapterItem.GUID -Setting $Setting
+            $currentValue = Get-NetAdapterNetbiosOptionsFromRegistry `
+                -NetworkAdapterGUID $netAdapterItem.GUID `
+                -Setting $Setting
 
             # Only make changes if necessary
             if ($currentValue -ne $Setting)
@@ -178,9 +184,10 @@ function Set-TargetResource
                     -ResultClassName Win32_NetworkAdapterConfiguration `
                     -ErrorAction Stop
 
-                Set-NetAdapterNetbiosOptions -NetworkAdapterObject $netAdapterConfig `
-                                             -InterfaceAlias $netAdapterItem.NetConnectionID `
-                                             -Setting $Setting
+                Set-NetAdapterNetbiosOptions `
+                    -NetworkAdapterObject $netAdapterConfig `
+                    -InterfaceAlias $netAdapterItem.NetConnectionID `
+                    -Setting $Setting
             }
         }
     }
@@ -192,9 +199,10 @@ function Set-TargetResource
                     -ResultClassName Win32_NetworkAdapterConfiguration `
                     -ErrorAction Stop
 
-        Set-NetAdapterNetbiosOptions -NetworkAdapterObject $netAdapterConfig `
-                                     -InterfaceAlias $netAdapter.NetConnectionID `
-                                     -Setting $Setting
+        Set-NetAdapterNetbiosOptions `
+            -NetworkAdapterObject $netAdapterConfig `
+            -InterfaceAlias $netAdapter.NetConnectionID `
+            -Setting $Setting
     }
 }
 
@@ -269,8 +277,9 @@ function Get-NetAdapterNetbiosOptionsFromRegistry
     $currentErrorActionPreference = $ErrorActionPreference
     $ErrorActionPreference = 'SilentlyContinue'
 
-    $registryNetbiosOptions = Get-ItemPropertyValue -Name 'NetbiosOptions' `
-                    -Path "$($script:hklmInterfacesPath)\Tcpip_$($NetworkAdapterGUID)"
+    $registryNetbiosOptions = Get-ItemPropertyValue `
+        -Name 'NetbiosOptions' `
+        -Path "$($script:hklmInterfacesPath)\Tcpip_$($NetworkAdapterGUID)"
 
     $ErrorActionPreference = $currentErrorActionPreference
 

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.schema.mof
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.schema.mof
@@ -1,4 +1,3 @@
-
 [ClassVersion("1.0.0.0"), FriendlyName("NetBios")]
 class DSC_NetBios : OMI_BaseResource
 {

--- a/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
+++ b/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
@@ -32,7 +32,8 @@ function Get-TargetResource
         $($script:localizedData.GettingNetConnectionProfile) -f $InterfaceAlias
     ) -join '')
 
-    $result = Get-NetConnectionProfile -InterfaceAlias $InterfaceAlias
+    $result = Get-NetConnectionProfile `
+        -InterfaceAlias $InterfaceAlias
 
     return @{
         InterfaceAlias   = $result.InterfaceAlias
@@ -136,7 +137,8 @@ function Test-TargetResource
 
     Assert-ResourceProperty @PSBoundParameters
 
-    $current = Get-TargetResource -InterfaceAlias $InterfaceAlias
+    $current = Get-TargetResource `
+        -InterfaceAlias $InterfaceAlias
 
     if (-not [System.String]::IsNullOrEmpty($IPv4Connectivity) -and `
         ($IPv4Connectivity -ne $current.IPv4Connectivity))

--- a/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
+++ b/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
@@ -216,7 +216,7 @@ function Assert-ResourceProperty
         $NetworkCategory
     )
 
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Find-NetworkAdapter -Name $InterfaceAlias ))
     {
         New-InvalidOperationException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias)

--- a/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
+++ b/source/DSCResources/DSC_NetIPInterface/DSC_NetIPInterface.psm1
@@ -484,7 +484,8 @@ function Get-NetworkIPInterface
             $($script:localizedData.GettingNetIPInterfaceMessage) -f $InterfaceAlias, $AddressFamily
         ) -join '')
 
-    $netIPInterface = Get-NetIPInterface @PSBoundParameters -ErrorAction SilentlyContinue
+    $netIPInterface = Get-NetIPInterface @PSBoundParameters `
+        -ErrorAction SilentlyContinue
 
     if (-not $netIPInterface)
     {

--- a/source/DSCResources/DSC_NetworkTeam/DSC_NetworkTeam.psm1
+++ b/source/DSCResources/DSC_NetworkTeam/DSC_NetworkTeam.psm1
@@ -43,7 +43,9 @@ function Get-TargetResource
     }
 
     Write-Verbose -Message ($script:localizedData.GetTeamInfo -f $Name)
-    $networkTeam = Get-NetLBFOTeam -Name $Name -ErrorAction SilentlyContinue
+    $networkTeam = Get-NetLBFOTeam `
+        -Name $Name `
+        -ErrorAction SilentlyContinue
 
     if ($networkTeam)
     {
@@ -121,7 +123,9 @@ function Set-TargetResource
 
     Write-Verbose -Message ($script:localizedData.GetTeamInfo -f $Name)
 
-    $networkTeam = Get-NetLBFOTeam -Name $Name -ErrorAction SilentlyContinue
+    $networkTeam = Get-NetLBFOTeam `
+        -Name $Name `
+        -ErrorAction SilentlyContinue
 
     if ($Ensure -eq 'Present')
     {
@@ -153,7 +157,9 @@ function Set-TargetResource
             {
                 Write-Verbose -Message ($script:localizedData.ModifyTeam -f $Name)
 
-                Set-NetLbfoTeam @setArguments -ErrorAction Stop -Confirm:$false
+                Set-NetLbfoTeam @setArguments `
+                    -ErrorAction Stop `
+                    -Confirm:$false
             }
 
             $netTeamMembers = Compare-Object `
@@ -172,7 +178,8 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ($script:localizedData.RemovingMembers -f ($membersToRemove -join ','))
 
-                    $null = Remove-NetLbfoTeamMember -Name $membersToRemove `
+                    $null = Remove-NetLbfoTeamMember `
+                        -Name $membersToRemove `
                         -Team $Name `
                         -ErrorAction Stop `
                         -Confirm:$false
@@ -186,7 +193,8 @@ function Set-TargetResource
                 {
                     Write-Verbose -Message ($script:localizedData.AddingMembers -f ($membersToAdd -join ','))
 
-                    $null = Add-NetLbfoTeamMember -Name $membersToAdd `
+                    $null = Add-NetLbfoTeamMember `
+                        -Name $membersToAdd `
                         -Team $Name `
                         -ErrorAction Stop `
                         -Confirm:$false
@@ -221,7 +229,10 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.RemoveTeam -f $Name)
 
-        $null = Remove-NetLbfoTeam -Name $name -ErrorAction Stop -Confirm:$false
+        $null = Remove-NetLbfoTeam `
+            -Name $name `
+            -ErrorAction Stop `
+            -Confirm:$false
     }
 }
 
@@ -277,7 +288,9 @@ function Test-TargetResource
 
     Write-Verbose -Message ($script:localizedData.GetTeamInfo -f $Name)
 
-    $networkTeam = Get-NetLbfoTeam -Name $Name -ErrorAction SilentlyContinue
+    $networkTeam = Get-NetLbfoTeam `
+        -Name $Name `
+        -ErrorAction SilentlyContinue
 
     if ($ensure -eq 'Present')
     {

--- a/source/DSCResources/DSC_NetworkTeamInterface/DSC_NetworkTeamInterface.schema.mof
+++ b/source/DSCResources/DSC_NetworkTeamInterface/DSC_NetworkTeamInterface.schema.mof
@@ -1,4 +1,3 @@
-
 [ClassVersion("1.0"), FriendlyName("NetworkTeamInterface")]
 class DSC_NetworkTeamInterface : OMI_BaseResource
 {

--- a/source/DSCResources/DSC_ProxySettings/DSC_ProxySettings.psm1
+++ b/source/DSCResources/DSC_ProxySettings/DSC_ProxySettings.psm1
@@ -60,7 +60,8 @@ function Get-TargetResource
     {
         $returnValue.Add('Ensure','Present')
 
-        $proxySettings = ConvertFrom-ProxySettingsBinary -ProxySettings $proxySettingsRegistryBinary
+        $proxySettings = ConvertFrom-ProxySettingsBinary `
+            -ProxySettings $proxySettingsRegistryBinary
 
         $returnValue.Add('EnableManualProxy',$proxySettings.EnableManualProxy)
         $returnValue.Add('EnableAutoConfiguration',$proxySettings.EnableAutoConfiguration)
@@ -392,14 +393,17 @@ function Test-TargetResource
 
             if ($connectionsRegistryValues.DefaultConnectionSettings)
             {
-                $defaultConnectionSettings = ConvertFrom-ProxySettingsBinary -ProxySettings $connectionsRegistryValues.DefaultConnectionSettings
+                $defaultConnectionSettings = ConvertFrom-ProxySettingsBinary `
+                    -ProxySettings $connectionsRegistryValues.DefaultConnectionSettings
             }
             else
             {
                 $defaultConnectionSettings = @{}
             }
 
-            $inDesiredState = Test-ProxySettings -CurrentValues $defaultConnectionSettings -DesiredValues $desiredValues
+            $inDesiredState = Test-ProxySettings `
+                -CurrentValues $defaultConnectionSettings `
+                -DesiredValues $desiredValues
 
             if (-not $inDesiredState)
             {
@@ -420,14 +424,17 @@ function Test-TargetResource
 
             if ($connectionsRegistryValues.SavedLegacySettings)
             {
-                $savedLegacySettings = ConvertFrom-ProxySettingsBinary -ProxySettings $connectionsRegistryValues.SavedLegacySettings
+                $savedLegacySettings = ConvertFrom-ProxySettingsBinary `
+                    -ProxySettings $connectionsRegistryValues.SavedLegacySettings
             }
             else
             {
                 $savedLegacySettings = @{}
             }
 
-            $inDesiredState = Test-ProxySettings -CurrentValues $savedLegacySettings -DesiredValues $desiredValues
+            $inDesiredState = Test-ProxySettings `
+                -CurrentValues $savedLegacySettings `
+                -DesiredValues $desiredValues
 
             if (-not $inDesiredState)
             {
@@ -792,7 +799,9 @@ function ConvertFrom-ProxySettingsBinary
 
         # Extract the Proxy Server string
         $proxyServer = ''
-        $stringLength = Get-Int32FromByteArray -Byte $ProxySettings -StartByte $stringPointer
+        $stringLength = Get-Int32FromByteArray `
+            -Byte $ProxySettings `
+            -StartByte $stringPointer
         $stringPointer += 4
 
         if ($stringLength -gt 0)
@@ -807,7 +816,9 @@ function ConvertFrom-ProxySettingsBinary
 
         # Extract the Proxy Server Exceptions string
         $proxyServerExceptions = @()
-        $stringLength = Get-Int32FromByteArray -Byte $ProxySettings -StartByte $stringPointer
+        $stringLength = Get-Int32FromByteArray `
+            -Byte $ProxySettings `
+            -StartByte $stringPointer
         $stringPointer += 4
 
         if ($stringLength -gt 0)

--- a/source/DSCResources/DSC_Route/DSC_Route.psm1
+++ b/source/DSCResources/DSC_Route/DSC_Route.psm1
@@ -613,7 +613,7 @@ function Assert-ResourceProperty
     )
 
     # Validate the Adapter exists
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Find-NetworkAdapter -Name $InterfaceAlias ))
     {
         New-InvalidArgumentException `
             -Message $($($script:localizedData.InterfaceNotAvailableError) -f $InterfaceAlias) `

--- a/source/DSCResources/DSC_WaitForNetworkTeam/DSC_WaitForNetworkTeam.schema.mof
+++ b/source/DSCResources/DSC_WaitForNetworkTeam/DSC_WaitForNetworkTeam.schema.mof
@@ -1,4 +1,3 @@
-
 [ClassVersion("1.0.0.0"), FriendlyName("WaitForNetworkTeam")]
 class DSC_WaitForNetworkTeam : OMI_BaseResource
 {

--- a/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.psm1
+++ b/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.psm1
@@ -150,7 +150,7 @@ function Assert-ResourceProperty
         $Address
     )
 
-    if (-not (Get-NetAdapter | Where-Object Name -EQ $InterfaceAlias))
+    if (-not (Find-NetworkAdapter -Name $InterfaceAlias))
     {
         New-InvalidArgumentException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias) `

--- a/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.psm1
+++ b/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.psm1
@@ -77,7 +77,10 @@ function Set-TargetResource
 
     Write-Verbose -Message "$($MyInvocation.MyCommand): $($script:localizedData.ApplyingWinsServerAddressesMessage)"
 
-    Set-WinsClientServerStaticAddress -InterfaceAlias $InterfaceAlias -Address $Address -ErrorAction Stop
+    Set-WinsClientServerStaticAddress `
+        -InterfaceAlias $InterfaceAlias `
+        -Address $Address `
+        -ErrorAction Stop
 
 }
 

--- a/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -396,7 +396,9 @@ function Get-WinsClientServerStaticAddress
     Write-Verbose -Message ("$($MyInvocation.MyCommand): $($script:localizedData.GettingWinsServerStaticAddressMessage -f $InterfaceAlias)")
 
     # Look up the interface Guid
-    $adapter = Get-NetAdapter -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+    $adapter = Get-NetAdapter `
+        -InterfaceAlias $InterfaceAlias `
+        -ErrorAction SilentlyContinue
 
     if (-not $adapter)
     {
@@ -458,7 +460,9 @@ function Set-WinsClientServerStaticAddress
     Write-Verbose -Message ("$($MyInvocation.MyCommand): $($script:localizedData.SettingWinsServerStaticAddressMessage -f $InterfaceAlias, ($Address -join ', '))")
 
     # Look up the interface Guid
-    $adapter = Get-NetAdapter -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+    $adapter = Get-NetAdapter `
+        -InterfaceAlias $InterfaceAlias `
+        -ErrorAction SilentlyContinue
 
     if (-not $adapter)
     {

--- a/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -97,6 +97,9 @@ function Convert-CIDRToSubhetMask
     .PARAMETER InterfaceDescription
         This is the interface description of the network adapter to find.
 
+    .PARAMETER IncludeHidden
+        This switch indicates the adapter to find may be hidden.
+
     .PARAMETER InterfaceIndex
         This is the interface index of the network adapter to find.
 
@@ -141,6 +144,10 @@ function Find-NetworkAdapter
         [Parameter()]
         [System.String]
         $InterfaceDescription,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $true,
 
         [Parameter()]
         [System.UInt32]
@@ -215,13 +222,13 @@ function Find-NetworkAdapter
                 $($script:localizedData.AllNetAdaptersFoundMessage)
             ) -join '')
 
-        $matchingAdapters = @(Get-NetAdapter)
+        $matchingAdapters = @(Get-NetAdapter -IncludeHidden:$IncludeHidden)
     }
     else
     {
         # Join all the filters together
         $adapterFilterScript = '(' + ($adapterFilters -join ' -and ') + ')'
-        $matchingAdapters = @(Get-NetAdapter |
+        $matchingAdapters = @(Get-NetAdapter -IncludeHidden:$IncludeHidden |
             Where-Object -FilterScript ([ScriptBlock]::Create($adapterFilterScript)))
     }
 
@@ -276,6 +283,7 @@ function Find-NetworkAdapter
         Status               = $exactAdapter.Status
         MacAddress           = $exactAdapter.MacAddress
         InterfaceDescription = $exactAdapter.InterfaceDescription
+        IncludeHidden        = $IncludeHidden
         InterfaceIndex       = $exactAdapter.InterfaceIndex
         InterfaceGuid        = $exactAdapter.InterfaceGuid
         MatchingAdapterCount = $matchingAdapters.Count
@@ -323,6 +331,7 @@ function Get-DnsClientServerStaticAddress
     # Look up the interface Guid
     $adapter = Get-NetAdapter `
         -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$true `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)
@@ -398,6 +407,7 @@ function Get-WinsClientServerStaticAddress
     # Look up the interface Guid
     $adapter = Get-NetAdapter `
         -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$true `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)
@@ -462,6 +472,7 @@ function Set-WinsClientServerStaticAddress
     # Look up the interface Guid
     $adapter = Get-NetAdapter `
         -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$true `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)


### PR DESCRIPTION
#### Pull Request (PR) description
NetAdapter module Cmdlets have an -IncludeHidden flag which allows access to adapters which are hidden; enable that flag by default except for NetAdapterName. Add IncludeHidden as configurable parameter to NetAdapterName.

NOTE: this is patch based off #496, so there's a lot of whitespace change. I made #496 specifically to make this diff much simpler.

#### This Pull Request (PR) fixes the following issues
- Fixes #499 

#### Task list
- [ ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
